### PR TITLE
flake: add meta.mainProgram

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
               description = "";
               homepage = "https://github.com/Golem-Base/op-geth";
               license = licenses.gpl3Only;
+              mainProgram = "geth";
             };
           };
         }


### PR DESCRIPTION
This allows using `pkgs.lib.getExe pkgs.foo` instead of `${pkgs.foo}/bin/foo`