### PR TITLE
golem-base/script: make run_dev compatible with NixOS and Podman

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,10 @@
             sqlite
             overmind
             mongosh
+            openssl
+          ] ++ lib.optional pkgs.stdenv.hostPlatform.isLinux [
+            # For podman networking
+            slirp4netns
           ];
         };
       });

--- a/golem-base/script/start-mongodb-etl.sh
+++ b/golem-base/script/start-mongodb-etl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # This script starts the MongoDB ETL process for Golem Base.
@@ -34,20 +34,20 @@ check_mongo_status() {
 attempt=0
 while [ $attempt -lt $MAX_ATTEMPTS ]; do
   ((attempt++))
-  
+
   echo "Attempt $attempt/$MAX_ATTEMPTS: Checking MongoDB status..."
   STATUS=$(check_mongo_status)
-  
+
   if [ "$STATUS" = "1" ]; then
     echo "MongoDB is available and running in replica mode!"
     break
   fi
-  
+
   if [ $attempt -eq $MAX_ATTEMPTS ]; then
     echo "Failed to connect to MongoDB in replica mode after $MAX_ATTEMPTS attempts."
     exit 1
   fi
-  
+
   echo "MongoDB not ready yet or not in replica mode. Waiting $SLEEP_INTERVAL seconds..."
   sleep $SLEEP_INTERVAL
 done
@@ -62,24 +62,24 @@ echo "Waiting for RPC endpoint to be available..."
 attempt=0
 while [ $attempt -lt $MAX_ATTEMPTS ]; do
   ((attempt++))
-  
+
   echo "Attempt $attempt/$MAX_ATTEMPTS: Checking RPC endpoint status..."
   STATUS=$(check_rpc_status)
-  
+
   if [ "$STATUS" = "1" ]; then
     echo "RPC endpoint is available!"
     break
   fi
-  
+
   if [ $attempt -eq $MAX_ATTEMPTS ]; then
     echo "Failed to connect to RPC endpoint after $MAX_ATTEMPTS attempts."
     exit 1
   fi
-  
+
   echo "RPC endpoint not ready yet. Waiting $SLEEP_INTERVAL seconds..."
   sleep $SLEEP_INTERVAL
 done
 
 # Start the MongoDB ETL process
 echo "Starting MongoDB ETL process..."
-exec go run "${GOLEM_BASE_DIR}/etl/mongodb/" --wal "$WAL_PATH" --mongo-uri "$MONGO_URI" --rpc-endpoint "$RPC_ENDPOINT" --db-name "$DB_NAME" 
+exec go run "${GOLEM_BASE_DIR}/etl/mongodb/" --wal "$WAL_PATH" --mongo-uri "$MONGO_URI" --rpc-endpoint "$RPC_ENDPOINT" --db-name "$DB_NAME"

--- a/golem-base/script/wait-for-rpc-and-start-sqlite-etl.sh
+++ b/golem-base/script/wait-for-rpc-and-start-sqlite-etl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # This script waits for the RPC endpoint to become available and then starts the SQLite ETL process.
@@ -36,12 +36,12 @@ check_rpc() {
 attempt=1
 while [ $attempt -le $MAX_ATTEMPTS ]; do
   echo "Attempt $attempt of $MAX_ATTEMPTS: Checking RPC availability..."
-  
+
   if check_rpc; then
     echo "RPC endpoint is available! Starting ETL process..."
     break
   fi
-  
+
   echo "RPC endpoint not available yet. Waiting ${SLEEP_SECONDS} seconds..."
   sleep $SLEEP_SECONDS
   attempt=$((attempt + 1))
@@ -54,4 +54,4 @@ fi
 
 # Start the ETL process
 echo "Starting SQLite ETL process..."
-exec go run "${GOLEM_BASE_DIR}/etl/sqlite/" --wal "${WAL_PATH}" --db "${DB_PATH}" --rpc-endpoint "${RPC_ENDPOINT}" 
+exec go run "${GOLEM_BASE_DIR}/etl/sqlite/" --wal "${WAL_PATH}" --db "${DB_PATH}" --rpc-endpoint "${RPC_ENDPOINT}"


### PR DESCRIPTION
I had to make some changes to the `run_dev` script to make it work on nixos (there were some hard-coded `/bin/bash` shebangs)
and to make it work with podman instead of docker (some differences in the arguments to `docker run`).

(Like half of the changes are just removing spurious whitespace, which my editor does by default, I can leave that out if needed.)
