### PR TITLE
flake: only biuld geth subpackage

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,15 +46,7 @@
             src = ./.;
 
             subPackages = [
-              "cmd/abidump"
-              "cmd/abigen"
-              "cmd/clef"
-              "cmd/devp2p"
-              "cmd/ethkey"
-              "cmd/evm"
               "cmd/geth"
-              "cmd/rlpdump"
-              "cmd/utils"
             ];
 
             proxyVendor = true;


### PR DESCRIPTION
We don't need the other CLI tools, and they slow down CI builds.