### PR TITLE
Updated first line, the modue line, of root go.mod with updated repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ethereum/go-ethereum
+module github.com/Golem-Base/golembase-op-geth
 
 go 1.23.0
 


### PR DESCRIPTION
Updated first line, the module line, of root go.mod with updated repo name so that we can build go apps without cloning the repo. Presently if we attempt to do so, we get this error:

```
github.com/Golem-Base/golembase-op-geth/cmd/golembase/account/pkg/useraccount: github.com/Golem-Base/golembase-op-geth@v1.101503.1-laika: parsing go.mod:
module declares its path as: github.com/ethereum/go-ethereum
    but was required as: github.com/Golem-Base/golembase-op-geth
```