### PR TITLE
Updated deletion for special case where deleted item is last in list

### DIFF
--- a/golem-base/storageutil/keyset/key_set.go
+++ b/golem-base/storageutil/keyset/key_set.go
@@ -123,19 +123,29 @@ func RemoveValue(db StateAccess, setKey common.Hash, value common.Hash) error {
 	lastElementAddress.Add(lastElementAddress, arrayLen)
 	lastElementValue := db.GetState(storageutil.GolemDBAddress, lastElementAddress.Bytes32())
 
-	// store the last element in the place of the value to remove
-	db.SetState(storageutil.GolemDBAddress, toRemoveAddress.Bytes32(), lastElementValue)
+	// Special case when the item being removed is the last in the array
+	if toRemoveAddress == lastElementAddress {
+		// decrement the length of the array
+		arrayLen.SubUint64(arrayLen, 1)
+		db.SetState(storageutil.GolemDBAddress, setKey, arrayLen.Bytes32())
 
-	// decrement the length of the array
-	arrayLen.SubUint64(arrayLen, 1)
-	db.SetState(storageutil.GolemDBAddress, setKey, arrayLen.Bytes32())
+		// clear last slot in the array
+		db.SetState(storageutil.GolemDBAddress, lastElementAddress.Bytes32(), zeroHash)
+	} else {
+		// store the last element in the place of the value to remove
+		db.SetState(storageutil.GolemDBAddress, toRemoveAddress.Bytes32(), lastElementValue)
 
-	// update the mapping for the last element
-	lastElementMapKey := crypto.Keccak256Hash([]byte("golemBase.keyset.map"), setKey[:], lastElementValue[:])
-	db.SetState(storageutil.GolemDBAddress, lastElementMapKey, arrayIndex.Bytes32())
+		// decrement the length of the array
+		arrayLen.SubUint64(arrayLen, 1)
+		db.SetState(storageutil.GolemDBAddress, setKey, arrayLen.Bytes32())
 
-	// clear last slot in the array
-	db.SetState(storageutil.GolemDBAddress, lastElementAddress.Bytes32(), zeroHash)
+		// update the mapping for the last element
+		lastElementMapKey := crypto.Keccak256Hash([]byte("golemBase.keyset.map"), setKey[:], lastElementValue[:])
+		db.SetState(storageutil.GolemDBAddress, lastElementMapKey, arrayIndex.Bytes32())
+
+		// clear last slot in the array
+		db.SetState(storageutil.GolemDBAddress, lastElementAddress.Bytes32(), zeroHash)
+	}
 
 	return nil
 


### PR DESCRIPTION
The code for deleting an item in the keyset breaks when the item being deleted is the last in the list. And the update does a delete before adding the items back in. And that deletion in turn causes the Add Entity to fail; it thinks the item is already in the list. Then the length gets off by 1, which causes further changes to break.