### PR TITLE
Validate annotation keys when entities are created/updated

### DIFF
--- a/golem-base/query/eval_test.go
+++ b/golem-base/query/eval_test.go
@@ -30,6 +30,12 @@ func TestEqualExpr(t *testing.T) {
 				"test":  []common.Hash{common.HexToHash("0x1")},
 				"test2": []common.Hash{common.HexToHash("0x2")},
 			},
+			"déçevant": {
+				"non": []common.Hash{common.HexToHash("0x3")},
+			},
+			"بروح": {
+				"ايوة": []common.Hash{common.HexToHash("0x3")},
+			},
 		},
 		numericAnnotations: map[string]map[uint64][]common.Hash{},
 	}
@@ -41,6 +47,27 @@ func TestEqualExpr(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, []common.Hash{common.HexToHash("0x1")}, res)
+
+	// Query for a key with special characters
+	expr, err = query.Parse("déçevant = \"non\"")
+	require.NoError(t, err)
+
+	res, err = expr.Evaluate(ds)
+	require.NoError(t, err)
+
+	require.Equal(t, []common.Hash{common.HexToHash("0x3")}, res)
+
+	expr, err = query.Parse("بروح = \"ايوة\"")
+	require.NoError(t, err)
+
+	res, err = expr.Evaluate(ds)
+	require.NoError(t, err)
+
+	require.Equal(t, []common.Hash{common.HexToHash("0x3")}, res)
+
+	// But symbols should fail
+	expr, err = query.Parse("foo@ = \"bar\"")
+	require.Error(t, err)
 }
 
 func TestNumericEqualExpr(t *testing.T) {

--- a/golem-base/query/language.go
+++ b/golem-base/query/language.go
@@ -6,6 +6,8 @@ import (
 	"github.com/alecthomas/participle/v2"
 	"github.com/alecthomas/participle/v2/lexer"
 	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum/go-ethereum/golem-base/storageutil/entity"
 )
 
 // Define the lexer with distinct tokens for each operator and parentheses.
@@ -18,7 +20,7 @@ var lex = lexer.MustSimple([]lexer.SimpleRule{
 	{Name: "Eq", Pattern: `=`},
 	{Name: "String", Pattern: `"(?:[^"\\]|\\.)*"`},
 	{Name: "Number", Pattern: `[0-9]+`},
-	{Name: "Ident", Pattern: `[a-zA-Z_][a-zA-Z0-9_]*`},
+	{Name: "Ident", Pattern: entity.AnnotationIdentRegex},
 })
 
 // Expression is the top-level rule.

--- a/golem-base/storageutil/entity/store_entity.go
+++ b/golem-base/storageutil/entity/store_entity.go
@@ -2,6 +2,7 @@ package entity
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/golem-base/storageutil"
@@ -12,6 +13,10 @@ import (
 	"github.com/ethereum/go-ethereum/golem-base/storageutil/keyset"
 )
 
+const AnnotationIdentRegex string = `[\p{L}_][\p{L}\p{N}_]*`
+
+var annotationIdentRegexCompiled *regexp.Regexp = regexp.MustCompile(fmt.Sprintf("^%s$", AnnotationIdentRegex))
+
 type StateAccess = storageutil.StateAccess
 
 func Store(
@@ -21,6 +26,24 @@ func Store(
 	emd EntityMetaData,
 	payload []byte,
 ) error {
+
+	// Validate the annotation identifiers
+	for _, annotation := range emd.StringAnnotations {
+		if !annotationIdentRegexCompiled.MatchString(annotation.Key) {
+			return fmt.Errorf("Invalid annotation identifier (must match `%s`): %s",
+				annotationIdentRegexCompiled.String(),
+				annotation.Key,
+			)
+		}
+	}
+	for _, annotation := range emd.NumericAnnotations {
+		if !annotationIdentRegexCompiled.MatchString(annotation.Key) {
+			return fmt.Errorf("Invalid annotation identifier (must match `%s`): %s",
+				annotationIdentRegexCompiled.String(),
+				annotation.Key,
+			)
+		}
+	}
 
 	err := allentities.AddEntity(access, key)
 	if err != nil {


### PR DESCRIPTION
This makes sure that we only create annotations that we can also query for.
